### PR TITLE
Add logstash transport support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,14 @@
       "integrity": "sha512-+rabAZZ3Yn7tF/XPGHupKIL5EcAbrLxnTr/hgQICxbeuAfWtT0UZSfULE+ndusckBItcv4o6ZeOJplQikVcLvQ==",
       "dev": true
     },
+    "@types/winston": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@types/winston/-/winston-2.4.4.tgz",
+      "integrity": "sha512-BVGCztsypW8EYwJ+Hq+QNYiT/MUyCif0ouBH+flrY66O5W+KIXAMML6E/0fJpm7VjIzgangahl5S03bJJQGrZw==",
+      "requires": {
+        "winston": "*"
+      }
+    },
     "ansi-align": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
@@ -2412,6 +2420,15 @@
         "stack-trace": "0.0.x",
         "triple-beam": "^1.3.0",
         "winston-transport": "^4.3.0"
+      }
+    },
+    "winston-logstash-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/winston-logstash-transport/-/winston-logstash-transport-2.0.0.tgz",
+      "integrity": "sha512-Ku9DgDqvCKZQbsEL9bAVxus6oUbWpCQMt4J7Z6JwrvWCHaWU5KyumaSZO6ZYW1St7h0iaCZAAQU0yRewM8o23Q==",
+      "requires": {
+        "@types/winston": "^2.3.9",
+        "winston": "^3.0.0"
       }
     },
     "winston-sentry-raven-transport": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "moment": "^2.24.0",
     "winston": "^3.2.1",
+    "winston-logstash-transport": "^2.0.0",
     "winston-sentry-raven-transport": "^1.0.2"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,11 @@
 import * as winston from 'winston';
 import WinstonSentryRavenTransport from 'winston-sentry-raven-transport';
-import {loggerFactoryGenerator} from './logger-factory-generator';
+import { LogstashTransport } from 'winston-logstash-transport';
+import { loggerFactoryGenerator } from './logger-factory-generator';
 
 export const loggerFactory = loggerFactoryGenerator({
     winston,
     consoleTransportClass: winston.transports.Console,
     sentryTransportClass: WinstonSentryRavenTransport,
+    logstashTransportClass: LogstashTransport,
 });

--- a/src/logger-factory-generator.test.ts
+++ b/src/logger-factory-generator.test.ts
@@ -17,6 +17,13 @@ class FakeConsoleTransport extends TransportStream {
     }
 }
 
+let lastLogstashLog;
+class FakeLogstashTransport extends TransportStream {
+    log(info) {
+        lastLogstashLog = info;
+    }
+}
+
 let logger;
 const symbolMessage= Symbol.for('message');
 const symbolLevel= Symbol.for('level');
@@ -25,14 +32,32 @@ describe('gupy-logger', () => {
     beforeEach(()=>{
         lastConsoleLog = null;
         lastSentryLog = null;
+        lastLogstashLog = null;
         const loggerFactory = loggerFactoryGenerator({
             winston,
             consoleTransportClass: FakeConsoleTransport,
-            sentryTransportClass: FakeSentryTransport
+            sentryTransportClass: FakeSentryTransport,
+            logstashTransportClass: FakeLogstashTransport,
         });
         logger = loggerFactory({
-            config: {sentry: {enabled: true, dsn: 'any', level: 'info'}}
+            config: {sentry: {enabled: true, dsn: 'any', level: 'info'},
+            logstash: {enabled: true, host: 'logstashhost', port: 12345, level: 'info'}}
         });
+    });
+
+    it('should init without logstash by default', () => {
+        const loggerFactory = loggerFactoryGenerator({
+            winston,
+            consoleTransportClass: FakeConsoleTransport,
+            sentryTransportClass: FakeSentryTransport,
+            logstashTransportClass: undefined,
+        });
+
+        logger = loggerFactory({
+            config: {sentry: {enabled: true, dsn: 'any', level: 'info'}},
+        });
+
+        expect(logger).be.not.equal(undefined);
     });
 
     it('should log debug nowhere', () => {
@@ -40,43 +65,62 @@ describe('gupy-logger', () => {
         expect(lastSentryLog).to.equal(null);
         expect(lastConsoleLog).to.deep.equal(null);
         expect(lastSentryLog).to.deep.equal(null);
+        expect(lastLogstashLog).to.deep.equal(null);
     });
 
-    it('should log info only at console', () => {
-        logger.info('any info');
-        expect(lastSentryLog).to.equal(null);
-        expect(lastConsoleLog).to.deep.equal({
+    it('should log info only at console and logstash', () => {
+        const expectedLog = {
             level: 'info',
             message: 'any info'
-        });
+        };
+
+        logger.info('any info');
+
+        expect(lastSentryLog).to.equal(null);
+        expect(lastConsoleLog).to.deep.equal(expectedLog);
+        expect(lastLogstashLog.application).to.equal('gupy');
+        expect(lastLogstashLog.message).to.equal('any info');
+        expect(lastLogstashLog.level).to.equal('info');
+
         expect(lastConsoleLog[symbolMessage]).to.match(/\d{4}-\d{2}-\d{2} \d{2}:\d{2} \+\d{2}:\d{2} \[info]: any info/);
         expect(lastConsoleLog[symbolLevel]).to.equal('info');
     });
 
-    it('should log warn only at console', () => {
-        logger.warn('any warn');
-        expect(lastSentryLog).to.equal(null);
-        expect(lastConsoleLog).to.deep.equal({
+    it('should log warn only at console and logstash', () => {
+        const expectedLog = {
             level: 'warn',
             message: 'any warn'
-        });
+        };
+
+        logger.warn('any warn');
+
+        expect(lastSentryLog).to.equal(null);
+        expect(lastConsoleLog).to.deep.equal(expectedLog);
+        expect(lastLogstashLog.application).to.equal('gupy');
+        expect(lastLogstashLog.message).to.equal('any warn');
+        expect(lastLogstashLog.level).to.equal('warn');
+
         expect(lastConsoleLog[symbolMessage]).to.match(/\d{4}-\d{2}-\d{2} \d{2}:\d{2} \+\d{2}:\d{2} \[warn]: any warn/);
         expect(lastConsoleLog[symbolLevel]).to.equal('warn');
     });
 
-    it('should log error at sentry and console', () => {
-        logger.error('any error');
-        expect(lastSentryLog).to.deep.equal({
+    it('should log error at all transport classes', () => {
+        const expectedLog = {
             level: 'error',
             message: 'any error'
-        });
+        };
+
+        logger.error('any error');
+
+        expect(lastLogstashLog.application).to.equal('gupy');
+        expect(lastLogstashLog.level).to.equal('error');
+        expect(lastLogstashLog.message).to.equal('any error');
+
+        expect(lastSentryLog).to.deep.equal(expectedLog);
         expect(lastSentryLog[symbolMessage]).to.match(/\d{4}-\d{2}-\d{2} \d{2}:\d{2} \+\d{2}:\d{2} \[error]: any error/);
         expect(lastSentryLog[symbolLevel]).to.equal('error');
 
-        expect(lastConsoleLog).to.be.deep.equal({
-            level: 'error',
-            message: 'any error'
-        });
+        expect(lastConsoleLog).to.be.deep.equal(expectedLog);
         expect(lastConsoleLog[symbolMessage]).to.match(/\d{4}-\d{2}-\d{2} \d{2}:\d{2} \+\d{2}:\d{2} \[error]: any error/);
         expect(lastConsoleLog[symbolLevel]).to.equal('error');
     });


### PR DESCRIPTION
Inclui suporte a enviar log para a stack ELK (elasticsearch, logstash and kibana)

Envia logs na porta udp do logstash, portanto não segura conexão durante envio do log.

exemplo de uso:
![Screenshot from 2019-07-26 15-46-12](https://user-images.githubusercontent.com/10155053/61975634-0725a500-afc0-11e9-8311-f1efb92a4688.png)

resultado:
![Screenshot from 2019-07-26 16-07-16](https://user-images.githubusercontent.com/10155053/61975655-160c5780-afc0-11e9-943c-d78d3705fdff.png)

Podemos enviar dados extras alem dos logs:
```
logger.info("Hello Logger!", {data: {headers: {}}});
```

