### PR TITLE
[CAND-2188] Add sentry sampleRate default to 0.25

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.loggerFactory = void 0;
 const winston = require("winston");
 const winstonSentryRavenTransport = require("winston-sentry-raven-transport");
 const winston_logstash_transport_1 = require("winston-logstash-transport");

--- a/dist/logger-factory-generator.d.ts
+++ b/dist/logger-factory-generator.d.ts
@@ -4,6 +4,7 @@ declare interface IConfig {
         enabled: boolean;
         dsn?: string;
         level?: string;
+        sampleRate?: number;
     };
     logstash?: {
         enabled?: boolean;

--- a/dist/logger-factory-generator.js
+++ b/dist/logger-factory-generator.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.loggerFactoryGenerator = void 0;
 const moment = require("moment");
 function prepareErrorToLog(error, messages = []) {
     if (messages.length) {
@@ -7,7 +8,7 @@ function prepareErrorToLog(error, messages = []) {
     }
     return error;
 }
-exports.loggerFactoryGenerator = ({ winston, consoleTransportClass, sentryTransportClass, logstashTransportClass }) => {
+const loggerFactoryGenerator = ({ winston, consoleTransportClass, sentryTransportClass, logstashTransportClass }) => {
     return ({ config }) => {
         const transports = [];
         transports.push(new consoleTransportClass({
@@ -17,6 +18,9 @@ exports.loggerFactoryGenerator = ({ winston, consoleTransportClass, sentryTransp
             transports.push(new sentryTransportClass({
                 dsn: config.sentry.dsn,
                 level: 'error',
+                config: {
+                    sampleRate: config.sentry.sampleRate || 0.25
+                }
             }));
         }
         if (config.logstash && config.logstash.enabled && logstashTransportClass) {
@@ -54,11 +58,11 @@ exports.loggerFactoryGenerator = ({ winston, consoleTransportClass, sentryTransp
                     messages.push(arg);
                 }
                 else if (typeof arg === 'object') {
-                    object = Object.assign({}, object, arg);
+                    object = Object.assign(Object.assign({}, object), arg);
                 }
             });
             if (error) {
-                return errorFn(prepareErrorToLog(error, messages), Object.assign({}, object, { stack: error.stack }));
+                return errorFn(prepareErrorToLog(error, messages), Object.assign(Object.assign({}, object), { stack: error.stack }));
             }
             else {
                 return errorFn.apply(logger, args);
@@ -67,3 +71,4 @@ exports.loggerFactoryGenerator = ({ winston, consoleTransportClass, sentryTransp
         return logger;
     };
 };
+exports.loggerFactoryGenerator = loggerFactoryGenerator;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2257,12 +2257,6 @@
         "yn": "^3.0.0"
       }
     },
-    "tsc": {
-      "version": "1.20150623.0",
-      "resolved": "https://registry.npmjs.org/tsc/-/tsc-1.20150623.0.tgz",
-      "integrity": "sha1-Trw8d04WkUjLx2inNCUz8ILHpuU=",
-      "dev": true
-    },
     "tslib": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
@@ -2306,9 +2300,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.3.tgz",
-      "integrity": "sha512-FFgHdPt4T/duxx6Ndf7hwgMZZjZpB+U0nMNGVCYPq0rEzWKjEDobm4J6yb3CS7naZ0yURFqdw9Gwc7UOh/P9oQ==",
+      "version": "4.1.5",
+      "resolved": "https://gpm-139818044667.d.codeartifact.us-east-1.amazonaws.com:443/npm/GupyPackageManager/typescript/-/typescript-4.1.5.tgz",
+      "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
       "dev": true
     },
     "unique-string": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "mocha": "^6.0.2",
     "npm-run-all": "^4.1.5",
     "ts-node": "^8.0.3",
-    "tsc": "^1.20150623.0",
-    "typescript": "^3.4.3"
+    "typescript": "^4.0.5"
   }
 }

--- a/src/logger-factory-generator.ts
+++ b/src/logger-factory-generator.ts
@@ -6,6 +6,7 @@ declare interface IConfig {
         enabled: boolean,
         dsn?: string,
         level?: string,
+        sampleRate?: number,
     };
     logstash?: {
         enabled?: boolean,
@@ -37,10 +38,15 @@ export const loggerFactoryGenerator = ({winston, consoleTransportClass, sentryTr
         }));
 
         if (config.sentry.enabled) {
-            transports.push(new sentryTransportClass({
+            transports.push(
+              new sentryTransportClass({
                 dsn: config.sentry.dsn,
-                level: 'error',
-            }));
+                level: "error",
+                config: {
+                  sampleRate: config.sentry.sampleRate || 0.25,
+                },
+              })
+            );
         }
 
         if (config.logstash && config.logstash.enabled && logstashTransportClass) {

--- a/src/logger-factory-generator.ts
+++ b/src/logger-factory-generator.ts
@@ -28,7 +28,7 @@ export interface IFactoryInterface {
     config: IConfig;
 }
 
-type LoggerFactoryType = ({config}: IFactoryInterface) => Logger;
+type LoggerFactoryType = ({ config }: IFactoryInterface) => Logger;
 
 export const loggerFactoryGenerator = ({winston, consoleTransportClass, sentryTransportClass, logstashTransportClass}): LoggerFactoryType => {
     return ({config}: IFactoryInterface) => {
@@ -38,15 +38,13 @@ export const loggerFactoryGenerator = ({winston, consoleTransportClass, sentryTr
         }));
 
         if (config.sentry.enabled) {
-            transports.push(
-              new sentryTransportClass({
+            transports.push(new sentryTransportClass({
                 dsn: config.sentry.dsn,
-                level: "error",
+                level: 'error',
                 config: {
-                  sampleRate: config.sentry.sampleRate || 0.25,
-                },
-              })
-            );
+                    sampleRate: config.sentry.sampleRate || 0.25
+                }
+            }));
         }
 
         if (config.logstash && config.logstash.enabled && logstashTransportClass) {
@@ -93,7 +91,7 @@ export const loggerFactoryGenerator = ({winston, consoleTransportClass, sentryTr
                 } else if (typeof arg === 'string') {
                     messages.push(arg);
                 } else if (typeof arg === 'object') {
-                    object = {...object, ...arg};
+                    object = { ...object, ...arg };
                 }
             });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,5 +7,8 @@
   },
   "include": [
     "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
   ]
 }


### PR DESCRIPTION
## Link para tarefa no Jira
[https://gupy-io.atlassian.net/browse/CAND-2188](https://gupy-io.atlassian.net/browse/CAND-2188)

## Descrição
Adiciona novo parâmetro `sampleRate` na inicialização do sentry como valor default de `0.25`
